### PR TITLE
Scrolling now propagated between iframes

### DIFF
--- a/filter.py
+++ b/filter.py
@@ -32,7 +32,7 @@ class Filter:
                 # Enlever la barre additionelle inutile des réseaux sociaux
                 for div in html.findAll('div', {'class' : 'addtoany_share_save_container addtoany_content_top'}):
                     div.extract()
-                
+
                 # Retrier les elements dans la barre de droite
                 aside = html.find('aside' , {'id' : 'secondary'})
                 toSort = {}
@@ -81,6 +81,20 @@ class Filter:
                 html.head.append(versionStyle)
                 versionBar.append(versionHeader)
                 html.body.insert(0, versionBar)
+                script = html.new_tag('script')
+                script.append('var just_scrolled = false;')
+                script.append('function reset_scroll() { just_scrolled = false; }')
+                script.append('function receiveMessage(event) { scroll_value = event.data; window.scrollTo(0, scroll_value); }')
+                script.append('window.addEventListener("message", receiveMessage, false);')
+                script.append('window.onscroll = function(e) { \
+                              if (just_scrolled) { \
+                                return; \
+                              } else { \
+                                just_scrolled = true; \
+                                window.parent.postMessage(window.scrollY, "*"); \
+                                setTimeout(reset_scroll, 50); \
+                              }};')
+                html.body.insert(0, script)
             # Mettre les changements dans la réponse
             flow.response.content = str(html).encode('utf-8')
 
@@ -90,7 +104,7 @@ class Filter:
         if '.css' in fileName:
             css_mod = re.sub('@media screen and \( ?min-width: ?\d+[.]?\d*', '@media screen and (min-width: 1', flow.response.text)
             css_mod = re.sub('@media screen and \( ?max-width: ?\d+[.]?\d*', '@media screen and (max-width: 1', css_mod)
-            css_mod = re.sub('@media screen and \( ?min-width: ?\d+[.]?\d*[a-z]* ?\) and \( ?max-width: ?\d+[.]?[a-z]* ?\)', '@media screen and (min-width: 1em) and (max-width: 1em)', css_mod) 
+            css_mod = re.sub('@media screen and \( ?min-width: ?\d+[.]?\d*[a-z]* ?\) and \( ?max-width: ?\d+[.]?[a-z]* ?\)', '@media screen and (min-width: 1em) and (max-width: 1em)', css_mod)
             css_mod = css_mod.replace('.admin-bar .site-navigation-fixed.navigation-top', '.admin-bar')
             # Modifier les couleurs en rouge (sans prendre les nuances de gris)
             it = re.finditer('\#[a-f 0-9]{6}', css_mod)


### PR DESCRIPTION
Allows to scroll an iframe when scrolling the other one. Works by using the postMessage API furnished by the browsers allowing communication by messages between windows.

For this to work, the page containing the two iframes should look like :

```
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
<html>
 <head>
   <meta charset="UTF-8">
   <title>title</title>
   <!--<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>-->
 </head>
 <body>
   <center>
     <iframe id="frame1" src="https://epfl.ch/" width="750" height="1000" scrolling="yes" style="display:inline"></iframe>
     <iframe id="frame2" src="https://epfl.ch/" width="750" height="1000" scrolling="yes" style="display:inline"></iframe>
   </center>
   <script>
     window.addEventListener("message", receiveMessage, false);
     function receiveMessage(event)
     {
         frame1_window = document.getElementById('frame1').contentWindow;
         frame2_window = document.getElementById('frame2').contentWindow;

         if (event.source === frame1_window) {
             frame2_window.postMessage(event.data, "*");
         } else {
             frame1_window.postMessage(event.data, "*");
         }
     }
   </script>
 </body>
</html>
```

The <script> part is really important here.

The beautiful thing with this solution is that it does not use any cross domain scripting hack to bypass browser security.