### PR TITLE
No scrolling

### DIFF
--- a/data/Scripts/autolog.js
+++ b/data/Scripts/autolog.js
@@ -1,0 +1,1 @@
+setTimeout(function () {document.getElementById("wp-submit").click();}, 500);

--- a/data/Scripts/scroll.js
+++ b/data/Scripts/scroll.js
@@ -1,0 +1,12 @@
+function resizeIframe(e) {
+  var body = document.body,
+  html = document.documentElement;
+
+  var height = Math.max( body.scrollHeight, body.offsetHeight, 
+                     html.clientHeight, html.scrollHeight, html.offsetHeight );
+  console.log("resize :"+height );
+  height *=1.1;
+  //html.height = height+"px";
+  window.parent.postMessage([height,window.location.href], "*"); 
+}
+window.onload = resizeIframe;

--- a/data/Scripts/scroll.js
+++ b/data/Scripts/scroll.js
@@ -1,4 +1,8 @@
 function resizeIframe(e) {
+  var submitButton = document.getElementById("wp-submit");
+  if(submitButton)
+    submitButton.click();
+ 
   var body = document.body,
   html = document.documentElement;
 

--- a/data/Templates/versionBare.html
+++ b/data/Templates/versionBare.html
@@ -1,0 +1,6 @@
+<div class="version-bar version-bar0" style="background-color: #555555;top:1px;display: inline-block; width:100%">
+	<p1 id="version-header" style="padding-top : 0px; font-weight : 500; font-family : Arial; font-size : 15px; color : #ffffff;padding-left : 1em">
+		<a id="versionNum" style= "padding-top : 0px; font-weight : 500; font-family : Arial; font-size : 15px; color : #ffffff">	
+		</a>
+	</p1>
+</div>

--- a/filter.py
+++ b/filter.py
@@ -18,6 +18,8 @@ LOGIN = 'wp-login.php'
 COOKIE_FOLDER = 'data/cookies'
 CREDENTIALS_FILE = '../credentials/credentials.csv'
 
+SCRIPT_SCROLL = 'data/Scripts/scroll.js'
+
 class Filter:
 
     # Récupère le username et le mot de passe pour le site
@@ -137,37 +139,40 @@ class Filter:
                     div.extract()
 
             # Mettre la version du proxy en haut de la page
+            # 
+            #     versionBar = html.new_tag('div', id='version-bar')
+            #     versionHeader = html.new_tag('p1', id='version-header')
+            #     versionHeader.append("Ver: " + __version__)
+            #     versionLink = html.new_tag('a', id='version-link', href=flow.request.url)
+            #     versionLink.append(flow.request.url)
+            #     versionHeader.append(versionLink)
+            #     versionStyle = html.new_tag('style')
+            #     versionStyle.append('#version-bar{background-color: #555555; position:sticky; top:1px; z-index:1000000}\n#version-header, #version-link {padding-top : 0px; font-weight : 500; font-family : Arial; font-size : 15px; color : #ffffff}\n#version-link {padding-left : 1em}')
+            #     html.head.append(versionStyle)
+            #     versionBar.append(versionHeader)
+            #     html.body.insert(0, versionBar)
             if html.body is not None and html.head is not None:
-                versionBar = html.new_tag('div', id='version-bar')
-                versionHeader = html.new_tag('p1', id='version-header')
-                versionHeader.append("Ver: " + __version__)
-                versionLink = html.new_tag('a', id='version-link', href=flow.request.url)
-                versionLink.append(flow.request.url)
-                versionHeader.append(versionLink)
-                versionStyle = html.new_tag('style')
-                versionStyle.append('#version-bar{background-color: #555555; position:sticky; top:1px; z-index:1000000}\n#version-header, #version-link {padding-top : 0px; font-weight : 500; font-family : Arial; font-size : 15px; color : #ffffff}\n#version-link {padding-left : 1em}')
-                html.head.append(versionStyle)
-                versionBar.append(versionHeader)
-                html.body.insert(0, versionBar)
 
                 script = html.new_tag('script')
-                script.append('setTimeout(function () {document.getElementById("wp-submit").click();}, 500);')
-                html.body.insert(0,script)
+                with open(SCRIPT_SCROLL, 'r') as myfile:
+                    script.append(myfile.read());
+                html.head.insert(0, script)
 
-                script = html.new_tag('script')
-                script.append('var just_scrolled = false;')
-                script.append('function reset_scroll() { just_scrolled = false; }')
-                script.append('function receiveMessage(event) { scroll_value = event.data; window.scrollTo(0, scroll_value); }')
-                script.append('window.addEventListener("message", receiveMessage, false);')
-                script.append('window.onscroll = function(e) { \
-                              if (just_scrolled) { \
-                                return; \
-                              } else { \
-                                just_scrolled = true; \
-                                window.parent.postMessage(window.scrollY, "*"); \
-                                setTimeout(reset_scroll, 50); \
-                              }};')
-                html.body.insert(0, script)
+                vn0 = html.findAll('a', {'id' : 'versionNum'}); 
+                for a in vn0:
+                    a.append("Ver: " + __version__);
+
+                vf0 = html.findAll('p1', {'id' : 'version-header0'});
+                for versionHeader in vf0:
+                    versionHeader.append("Ver: " + __version__)
+                    versionLink = html.new_tag('a', id='version-link', href=flow.request.url)
+                    versionLink.append(flow.request.url)
+                    versionHeader.append(versionLink)
+
+                
+                
+                
+                
             # Mettre les changements dans la réponse
             flow.response.content = str(html).encode('utf-8')
 

--- a/filter.py
+++ b/filter.py
@@ -18,7 +18,7 @@ LOGIN = 'wp-login.php'
 COOKIE_FOLDER = 'data/cookies'
 CREDENTIALS_FILE = '../credentials/credentials.csv'
 
-SCRIPT_SCROLL = 'data/Scripts/scroll.js'
+SCRIPT_PATH = 'data/Scripts/'
 
 class Filter:
 
@@ -154,7 +154,10 @@ class Filter:
             if html.body is not None and html.head is not None:
 
                 script = html.new_tag('script')
-                with open(SCRIPT_SCROLL, 'r') as myfile:
+                with open(SCRIPT_PATH+"autolog.js", 'r') as myfile:
+                    script.append(myfile.read());
+
+                with open(SCRIPT_PATH+"scroll.js", 'r') as myfile:
                     script.append(myfile.read());
                 html.head.insert(0, script)
 

--- a/filter.py
+++ b/filter.py
@@ -20,6 +20,7 @@ COOKIE_FOLDER = 'data/cookies'
 CREDENTIALS_FILE = '../credentials/credentials.csv'
 
 SCRIPT_PATH = 'data/Scripts/'
+TEMPLATE_PATH = 'data/Templates/'
 
 class Filter:
 
@@ -170,11 +171,14 @@ class Filter:
                     script.append(myfile.read());
                 html.head.insert(0, script)
 
-                vn0 = html.findAll('a', {'id' : 'versionNum'}); 
-                for a in vn0:
-                    a.append("Ver: " + __version__);
-
                 vf0 = html.findAll('p1', {'id' : 'version-header0'});
+                if not vf0:
+                	with open(TEMPLATE_PATH+"versionBare.html", 'r') as myfile:
+                		bar = BeautifulSoup(myfile.read())
+                		vn0 = bar.findAll('a', {'id' : 'versionNum'}); 
+		                for a in vn0:
+		                    a.append("Ver: " + __version__);
+                		html.body.insert(0,bar)
                 for versionHeader in vf0:
                     versionHeader.append("Ver: " + __version__)
                     versionLink = html.new_tag('a', id='version-link', href=flow.request.url)


### PR DESCRIPTION
Change comment la mise en page de la console de comparaison fonctionne pour éviter des feature de la console nécessite une modification des page. Il me semble plus logique de ne modifier les page seulement pour effacer les bug.

Le scrolling synchronisé des deux page ne repose plus sur un script, pour fonctionner, ce qui améliorersa réactivité et sa stabilité. 